### PR TITLE
Prevent applying email rule twice

### DIFF
--- a/src/fields/email.ts
+++ b/src/fields/email.ts
@@ -8,7 +8,13 @@ export interface IEmailSchema<V = undefined> extends IFieldSchemaBase<"email", V
 export const email: IFieldGenerator<IEmailSchema> = (id, { validation }) => {
 	const emailRule = validation?.find((rule) => rule.email);
 
+	let schema = Yup.string();
+	// no need to apply if it is defined as it will be applied in the mapRules() function
+	if (!emailRule?.email) {
+		schema = schema.email(ERROR_MESSAGES.EMAIL.INVALID);
+	}
+
 	return {
-		[id]: { yupSchema: Yup.string().email(emailRule?.errorMessage || ERROR_MESSAGES.EMAIL.INVALID), validation },
+		[id]: { yupSchema: schema, validation },
 	};
 };

--- a/src/fields/email.ts
+++ b/src/fields/email.ts
@@ -10,7 +10,7 @@ export const email: IFieldGenerator<IEmailSchema> = (id, { validation }) => {
 
 	let schema = Yup.string();
 	// no need to apply if it is defined as it will be applied in the mapRules() function
-	if (!emailRule?.email) {
+	if (!emailRule) {
 		schema = schema.email(ERROR_MESSAGES.EMAIL.INVALID);
 	}
 

--- a/src/schema-generator/json-to-schema.ts
+++ b/src/schema-generator/json-to-schema.ts
@@ -1,6 +1,7 @@
 import * as Yup from "yup";
 import { ObjectShape } from "yup/lib/object";
 import { TFieldsConfig, generateFieldConfigs } from "../fields";
+import { ERROR_MESSAGES } from "../shared";
 import {
 	CONDITIONS,
 	IConditionalValidationRule,
@@ -94,6 +95,8 @@ const mapRules = (yupSchema: Yup.AnySchema, rules: TFieldValidation): Yup.AnySch
 				yupSchema = yupSchema.required(rule.errorMessage || "This field is required");
 				break;
 			case !!rule.email:
+				yupSchema = (yupSchema as Yup.StringSchema).email(rule.errorMessage || ERROR_MESSAGES.EMAIL.INVALID);
+				break;
 			case !!rule.url:
 			case !!rule.uuid:
 			case !!rule.positive:


### PR DESCRIPTION
- MOL-12288
- Ensure email rule is not applied twice for `email` fields
- Also added fallback error message when applying `email` rule