### PR TITLE
ensure validation is removed for deeply nested conditionally hidden field

### DIFF
--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -273,9 +273,14 @@ describe("json-to-schema", () => {
 								uiType: "div",
 								showIf: [{ field1: [{ equals: "show wrapper" }] }],
 								children: {
-									field2: {
-										uiType: "numeric-field",
-										validation: [{ required: true, errorMessage: ERROR_MESSAGE_2 }],
+									nested: {
+										uiType: "div",
+										children: {
+											field2: {
+												uiType: "numeric-field",
+												validation: [{ required: true, errorMessage: ERROR_MESSAGE_2 }],
+											},
+										},
 									},
 								},
 							},

--- a/src/schema-generator/conditional-render.ts
+++ b/src/schema-generator/conditional-render.ts
@@ -125,10 +125,10 @@ const listAllChildIds = (children: unknown) => {
 	if (isEmpty(children) || !isObject(children)) {
 		return childIdList;
 	}
-	Object.keys(children).forEach((id) => {
+	Object.entries(children).forEach(([id, child]) => {
 		childIdList.push(id);
-		if (children["children"]) {
-			childIdList.push(...listAllChildIds(children["children"]));
+		if (child["children"]) {
+			childIdList.push(...listAllChildIds(child["children"]));
 		}
 	});
 


### PR DESCRIPTION
**Changes**
- fixed `listAllChildIds` reference to children so it can recurse correctly and remove validation accordingly
- updated test case to cover this scenario 