### PR TITLE
Cyclic validation fix

### DIFF
--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -17,6 +17,7 @@ module.exports = async () => ({
 	moduleNameMapper: {
 		"src/(.*)": "<rootDir>/src/$1",
 	},
+	setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup/jest.setup.ts"],
 	verbose: true,
 	bail: true,
 	reporters: ["default", ["jest-junit", { outputName: "junit.xml" }]],

--- a/src/__tests__/custom-rules/custom-rules.spec.ts
+++ b/src/__tests__/custom-rules/custom-rules.spec.ts
@@ -1,14 +1,9 @@
-import { applyCustomRules } from "../../custom-rules";
 import { jsonToSchema } from "../../schema-generator";
 import { TestHelper } from "../../utils";
 
 const ERROR_MESSAGE = "test error message";
 
 describe("custom-rules", () => {
-	beforeAll(() => {
-		applyCustomRules();
-	});
-
 	it.each`
 		type        | condition                 | uiType             | config                       | valid          | invalid
 		${"string"} | ${"uinfin"}               | ${"text-field"}    | ${{ uinfin: true }}          | ${"S1234567D"} | ${"S1234567A"}

--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -104,6 +104,48 @@ describe("json-to-schema", () => {
 			expect(error.inner[0].message).toBe(ERROR_MESSAGE);
 		});
 
+		it("should be able to create a schema without cyclic dependency", () => {
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field1: {
+							uiType: "text-field",
+							validation: [
+								{
+									when: {
+										field2: {
+											is: [{ empty: true }],
+											then: [{ required: true, errorMessage: ERROR_MESSAGE }],
+										},
+									},
+								},
+							],
+						},
+						field2: {
+							uiType: "text-field",
+							validation: [
+								{
+									when: {
+										field1: {
+											is: [{ empty: true }],
+											then: [{ required: true, errorMessage: ERROR_MESSAGE_2 }],
+										},
+									},
+								},
+							],
+						},
+					},
+				},
+			});
+
+			const error = TestHelper.getError(() => schema.validateSync({}, { abortEarly: false }));
+			expect(error.inner).toHaveLength(2);
+			expect(error.inner[0].message).toBe(ERROR_MESSAGE);
+			expect(error.inner[1].message).toBe(ERROR_MESSAGE_2);
+			expect(() => schema.validateSync({ field1: "hello" })).not.toThrow();
+		});
+
 		describe("overrides", () => {
 			const SCHEMA: TSectionsSchema = {
 				section: {

--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -1,5 +1,4 @@
 import { ObjectSchema } from "yup";
-import { applyCustomRules } from "../../custom-rules";
 import { TSectionsSchema, jsonToSchema } from "../../schema-generator";
 import { ERROR_MESSAGES } from "../../shared";
 import { TestHelper } from "../../utils";
@@ -197,10 +196,6 @@ describe("json-to-schema", () => {
 	});
 
 	describe("conditionalRender", () => {
-		beforeAll(() => {
-			applyCustomRules();
-		});
-
 		describe("conditionally hidden fields", () => {
 			let schema: ObjectSchema<ObjectShape>;
 

--- a/src/__tests__/setup/jest.setup.ts
+++ b/src/__tests__/setup/jest.setup.ts
@@ -1,0 +1,2 @@
+import { applyCustomRules } from "../../custom-rules";
+applyCustomRules();

--- a/src/fields/chips.ts
+++ b/src/fields/chips.ts
@@ -56,7 +56,7 @@ export const chips: IFieldGenerator<IChipsSchema> = (id, field) => {
 				when: {
 					...(textareaWhenRule?.when || {}),
 					[id]: {
-						is: [{ includes: [label] }],
+						is: [{ includes: [textarea?.label] }],
 						then: textareaWithoutWhenRule,
 					},
 				},


### PR DESCRIPTION
**Changes**
- Related to https://github.com/LifeSG/web-frontend-engine/pull/215
- added fix for Yup's cyclic dependency error based on https://github.com/jquense/yup/issues/176#issuecomment-367352042
- Refactor to apply custom validation rules to all test suites
- Additional fixes to chips textarea validation uncovered while making the change
- delete branch

**Additional information**
- this error happens when there fields with conditional validation that rely on each other
- e.g. field1 is required if field2 is empty and field2 is required if field1 is empty
- Yup is not able to determine which field comes first hence the error
- the workaround is to define the field pairs in the `shape()` method