### PR TITLE
Nested conditional validation

### DIFF
--- a/src/__tests__/fields/chips.spec.ts
+++ b/src/__tests__/fields/chips.spec.ts
@@ -125,6 +125,7 @@ describe("chips", () => {
 			schema.validateSync({ field: ["Apple", "More info"], "field-textarea": "hello" })
 		).not.toThrowError();
 	});
+
 	it("should support textarea validation config", () => {
 		const schema = jsonToSchema({
 			section: {
@@ -154,5 +155,62 @@ describe("chips", () => {
 		expect(
 			TestHelper.getError(() => schema.validateSync({ field: ["more info"], "field-textarea": "hello" })).message
 		).toBe(ERROR_MESSAGE_2);
+	});
+
+	it("should support conditional validation in textarea", () => {
+		const schema = jsonToSchema({
+			section: {
+				uiType: "section",
+				children: {
+					field1: {
+						uiType: "chips",
+						options: [
+							{ label: "Apple", value: "Apple" },
+							{ label: "Berry", value: "Berry" },
+							{ label: "Cherry", value: "Cherry" },
+						],
+						textarea: {
+							label: "more info",
+							validation: [
+								{
+									when: {
+										field2: {
+											is: [{ filled: true }],
+											then: [{ min: 10, errorMessage: ERROR_MESSAGE }],
+										},
+									},
+								},
+							],
+						},
+					},
+					field2: {
+						uiType: "text-field",
+					},
+				},
+			},
+		});
+
+		expect(() =>
+			schema.validateSync(
+				{
+					field1: ["more info"],
+					"field1-textarea": "hello world",
+					field2: "lorem",
+				},
+				{ abortEarly: false }
+			)
+		).not.toThrow();
+		expect(
+			TestHelper.getError(() =>
+				schema.validateSync(
+					{
+						field1: ["more info"],
+						"field1-textarea": "hello",
+						field2: "lorem",
+					},
+					{ abortEarly: false }
+				)
+			).message
+		).toBe(ERROR_MESSAGE);
 	});
 });

--- a/src/fields/chips.ts
+++ b/src/fields/chips.ts
@@ -46,24 +46,20 @@ export const chips: IFieldGenerator<IChipsSchema> = (id, field) => {
 		},
 	};
 
-	// formats textarea validation as conditional validation because it can't tell when to validate (i.e. doesn't know if user picked chip to show textarea)
-	let textareaValidation: IValidationRule = {};
 	if (textarea?.label) {
 		if (textarea?.validation) {
-			const textareaWithoutWhenRule = textarea?.validation?.filter((rule) => !("when" in rule));
-			const textareaWhenRule = textarea?.validation?.find((rule) => "when" in rule);
-			textareaValidation = {
+			// formats textarea validation as conditional validation because it can't tell when to validate (i.e. doesn't know if user picked chip to show textarea)
+			const textareaValidationRule: IValidationRule = {
 				when: {
-					...(textareaWhenRule?.when || {}),
 					[id]: {
 						is: [{ includes: [textarea?.label] }],
-						then: textareaWithoutWhenRule,
+						then: textarea?.validation,
 					},
 				},
 			};
 			fieldsConfig[`${id}-textarea`] = {
 				yupSchema: Yup.string(),
-				validation: [textareaValidation],
+				validation: [textareaValidationRule],
 			};
 		} else {
 			fieldsConfig[`${id}-textarea`] = {

--- a/src/schema-generator/types.ts
+++ b/src/schema-generator/types.ts
@@ -82,7 +82,7 @@ export interface IValidationRule extends IRule {
 		| {
 				[id: string]: {
 					is: string | number | boolean | string[] | number[] | boolean[] | IConditionalValidationRule[];
-					then: Omit<IValidationRule, "when">[];
+					then: IValidationRule[];
 					otherwise?: Omit<IValidationRule, "when">[] | undefined;
 					yupSchema?: Yup.AnySchema | undefined;
 				};


### PR DESCRIPTION
**Changes**
- Add support for nested conditional validation
  - Note: This works for the `then` key only and doesn't work for `otherwise` key
- Reworked chips textarea validation to use nested conditional validation
- FEE will be updated after this PR
- Delete branch

**Additional information**
- Current implementation only supports `OR` conditional validations
- Having nested conditional validation fulfils the `AND` conditional validations

```

// OR
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: "",
					otherwise: "",
				},
				field2: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		}
	]
}

// OR
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		},
		{
			when: {
				field2: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		}
	]
}

// AND
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: [{
						when: {
							field2: {
								is: "",
								then: "",
								otherwise: "",
							}
						}
					}],
					otherwise: "",
				},
		}
	]
}
```
