### PR TITLE
Ensure conditional rendering is overridden

### DIFF
--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -167,6 +167,26 @@ describe("json-to-schema", () => {
 				expect(error.inner[0].message).toBe(ERROR_MESSAGE_2);
 			});
 
+			it("should be able to override the schema with conditional render rules", () => {
+				const schema = jsonToSchema(SCHEMA, {
+					field: {
+						validation: [{ errorMessage: "overridden error 1" }],
+					},
+					field2: {
+						showIf: [{ field: [{ equals: "show field 2" }] }],
+						validation: [{ errorMessage: "overridden error 2" }],
+					},
+				});
+
+				expect(() => schema.validateSync({ field: "hello", field2: undefined })).not.toThrowError();
+
+				const error = TestHelper.getError(() =>
+					schema.validateSync({ field: "show field 2", field2: undefined }, { abortEarly: false })
+				);
+				expect(error.inner).toHaveLength(1);
+				expect(error.inner[0].message).toBe("overridden error 2");
+			});
+
 			it("should not change or remove entries on overriding with undefined values", () => {
 				const schema = jsonToSchema(SCHEMA, {
 					field: {

--- a/src/schema-generator/json-to-schema.ts
+++ b/src/schema-generator/json-to-schema.ts
@@ -38,7 +38,9 @@ export const jsonToSchema = <V = undefined>(
 		.shape(yupSchema, whenPairIds)
 		.noUnknown()
 		.meta({ schema: yupSchema })
-		.test("conditional-render", undefined, (values, context) => parseConditionalRenders(sections, values, context));
+		.test("conditional-render", undefined, (values, context) =>
+			parseConditionalRenders(overriddenSections, values, context)
+		);
 };
 
 export const overrideSchema = (


### PR DESCRIPTION
**Changes**

- Use overridden schema for subsequent processing
- Fixes issue where a field that is supposed to be conditionally rendered (using overrides) still fails validation
-   [delete] branch