### PR TITLE
Add shown condition

### DIFF
--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -418,4 +418,140 @@ describe("json-to-schema", () => {
 			});
 		});
 	});
+
+	describe("shown condition", () => {
+		it("should support shown condition for conditionally rendered fields", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field1: {
+							uiType,
+						},
+						field2: {
+							uiType,
+							showIf: [{ field1: [{ equals: "show" }] }],
+						},
+						field3: {
+							uiType,
+							showIf: [{ field2: [{ shown: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({})).not.toThrowError();
+			expect(() => schema.validateSync({ field1: "show", field2: "show", field3: "val" })).not.toThrowError();
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "show" })).message).toBe(ERROR_MESSAGE);
+			expect(TestHelper.getError(() => schema.validateSync({ field3: "val" })).message).toBe(
+				ERROR_MESSAGES.UNSPECIFIED_FIELD("field3")
+			);
+		});
+
+		it("should support shown condition as one of the conditional rendering rules", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field1: {
+							uiType,
+						},
+						field2: {
+							uiType,
+							showIf: [{ field1: [{ equals: "show" }] }],
+						},
+						field3: {
+							uiType,
+							showIf: [{ field2: [{ shown: true }, { filled: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({ field1: "show", field2: "" })).not.toThrowError();
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "show", field2: "val" })).message).toBe(
+				ERROR_MESSAGE
+			);
+		});
+
+		it("should support shown condition as one of the conditional rendering rules", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field1: {
+							uiType,
+						},
+						field2: {
+							uiType,
+							showIf: [{ field1: [{ equals: "show" }] }],
+						},
+						field3: {
+							uiType,
+						},
+						field4: {
+							uiType,
+							showIf: [{ field2: [{ shown: true }] }, { field3: [{ filled: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({ field1: "show", field4: "val" })).not.toThrowError();
+			expect(() => schema.validateSync({ field3: "val", field4: "val" })).not.toThrowError();
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "show" })).message).toBe(ERROR_MESSAGE);
+			expect(TestHelper.getError(() => schema.validateSync({ field3: "val" })).message).toBe(ERROR_MESSAGE);
+		});
+
+		it("should support shown conditions out of order", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field4: {
+							uiType,
+							showIf: [{ field3: [{ shown: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE_2 }],
+						},
+						field3: {
+							uiType,
+							showIf: [{ field2: [{ shown: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+				section2: {
+					uiType: "section",
+					children: {
+						field2: {
+							uiType,
+							showIf: [{ field1: [{ equals: "show" }] }],
+						},
+						field1: {
+							uiType,
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({ field1: "show", field3: "val", field4: "val" })).not.toThrowError();
+			expect(TestHelper.getError(() => schema.validateSync({ field3: "val" })).message).toBe(
+				ERROR_MESSAGES.UNSPECIFIED_FIELD("field3")
+			);
+			expect(TestHelper.getError(() => schema.validateSync({ field4: "val" })).message).toBe(
+				ERROR_MESSAGES.UNSPECIFIED_FIELD("field4")
+			);
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "show" })).message).toBe(ERROR_MESSAGE);
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "show", field3: "val" })).message).toBe(
+				ERROR_MESSAGE_2
+			);
+		});
+	});
 });

--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -509,7 +509,25 @@ describe("json-to-schema", () => {
 			expect(TestHelper.getError(() => schema.validateSync({ field3: "val" })).message).toBe(ERROR_MESSAGE);
 		});
 
-		it("should support shown conditions out of order", () => {
+		it("should still evaluate shown condition if source field is not defined", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field: {
+							uiType,
+							showIf: [{ missing: [{ shown: true }] }],
+							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({})).not.toThrowError();
+		});
+
+		it("should support shown conditions declared out of order", () => {
 			const uiType = "text-field";
 			const schema = jsonToSchema({
 				section: {

--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -465,7 +465,10 @@ describe("json-to-schema", () => {
 						},
 						field3: {
 							uiType,
-							showIf: [{ field2: [{ shown: true }, { filled: true }] }],
+						},
+						field4: {
+							uiType,
+							showIf: [{ field2: [{ shown: true }, { filled: true }] }, { field3: [{ filled: true }] }],
 							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
 						},
 					},
@@ -473,39 +476,10 @@ describe("json-to-schema", () => {
 			});
 
 			expect(() => schema.validateSync({ field1: "show", field2: "" })).not.toThrowError();
+			expect(() => schema.validateSync({ field3: "" })).not.toThrowError();
 			expect(TestHelper.getError(() => schema.validateSync({ field1: "show", field2: "val" })).message).toBe(
 				ERROR_MESSAGE
 			);
-		});
-
-		it("should support shown condition as one of the conditional rendering rules", () => {
-			const uiType = "text-field";
-			const schema = jsonToSchema({
-				section: {
-					uiType: "section",
-					children: {
-						field1: {
-							uiType,
-						},
-						field2: {
-							uiType,
-							showIf: [{ field1: [{ equals: "show" }] }],
-						},
-						field3: {
-							uiType,
-						},
-						field4: {
-							uiType,
-							showIf: [{ field2: [{ shown: true }] }, { field3: [{ filled: true }] }],
-							validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
-						},
-					},
-				},
-			});
-
-			expect(() => schema.validateSync({ field1: "show", field4: "val" })).not.toThrowError();
-			expect(() => schema.validateSync({ field3: "val", field4: "val" })).not.toThrowError();
-			expect(TestHelper.getError(() => schema.validateSync({ field1: "show" })).message).toBe(ERROR_MESSAGE);
 			expect(TestHelper.getError(() => schema.validateSync({ field3: "val" })).message).toBe(ERROR_MESSAGE);
 		});
 

--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -571,5 +571,35 @@ describe("json-to-schema", () => {
 				ERROR_MESSAGE_2
 			);
 		});
+
+		it("should not apply validation schema of hidden child field", () => {
+			const uiType = "text-field";
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field1: {
+							uiType,
+						},
+						field2: {
+							uiType,
+							showIf: [{ field1: [{ equals: "show" }] }],
+						},
+						wrapper: {
+							uiType: "div",
+							showIf: [{ field2: [{ shown: true }] }],
+							children: {
+								field3: {
+									uiType,
+									validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+								},
+							},
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({})).not.toThrowError();
+		});
 	});
 });

--- a/src/schema-generator/conditional-render.ts
+++ b/src/schema-generator/conditional-render.ts
@@ -56,7 +56,7 @@ const parseShownRule = (
 		.forEach(([fieldId, ruleGroups]) => {
 			const notShown = ruleGroups.every((rules) => {
 				if (rules.length) {
-					return rules.some((id) => parsedYupSchema[id].describe().meta?.hidden);
+					return rules.some((id) => !parsedYupSchema[id] || parsedYupSchema[id].describe().meta?.hidden);
 				}
 				return false;
 			});

--- a/src/schema-generator/field-sort.ts
+++ b/src/schema-generator/field-sort.ts
@@ -59,14 +59,19 @@ const topologicalSort = (dependencies: Record<string, string[]>) => {
 
 	// initialise graph representation
 	const edges: Record<string, string[]> = Object.fromEntries(fieldIds.map((id) => [id, []]));
-	const indegrees: Record<string, number> = Object.fromEntries(fieldIds.map((id) => [id, 0]));
-
 	Object.entries(dependencies).forEach(([childId, parentIds]) => {
 		parentIds.forEach((parentId) => {
+			if (!edges[parentId]) {
+				edges[parentId] = [];
+			}
 			edges[parentId].push(childId);
 		});
 	});
-	Object.entries(dependencies).forEach(([nodeId, parentIds]) => (indegrees[nodeId] = parentIds.length));
+
+	const indegrees: Record<string, number> = Object.fromEntries(Object.keys(edges).map((id) => [id, 0]));
+	Object.entries(dependencies).forEach(([nodeId, parentIds]) => {
+		indegrees[nodeId] = parentIds.length;
+	});
 
 	// begin graph traversal
 	const queue = [];
@@ -90,7 +95,7 @@ const topologicalSort = (dependencies: Record<string, string[]>) => {
 		}
 	}
 
-	if (order.length !== fieldIds.length) {
+	if (order.length !== Object.keys(edges).length) {
 		console.warn("cycle detected");
 	}
 

--- a/src/schema-generator/field-sort.ts
+++ b/src/schema-generator/field-sort.ts
@@ -1,0 +1,98 @@
+import isEmpty from "lodash/isEmpty";
+import isObject from "lodash/isObject";
+import { ICheckboxSchema, IRadioSchema } from "../fields";
+import { TComponentSchema, TRenderRules, TSectionsSchema } from "./types";
+
+export const getFieldSortOrder = (sections: TSectionsSchema): Record<string, number> => {
+	let dependencies: Record<string, string[]> = {};
+
+	Object.values(sections).forEach(({ children }) => {
+		dependencies = { ...dependencies, ...generateFieldDependencies(children) };
+	});
+
+	const sorted = topologicalSort(dependencies);
+	return sorted.reduce<Record<string, number>>((acc, entry, i) => {
+		acc[entry] = i;
+		return acc;
+	}, {});
+};
+
+const generateFieldDependencies = (childrenSchema: Record<string, TComponentSchema>) => {
+	let dependencies: Record<string, string[]> = {};
+
+	Object.entries(childrenSchema).forEach(([id, componentSchema]) => {
+		dependencies[id] = [];
+
+		(componentSchema.showIf as TRenderRules[])?.forEach((renderRules) =>
+			Object.entries(renderRules).forEach(([sourceFieldId, ruleGroup]) => {
+				if (ruleGroup.find((rule) => rule.shown)) {
+					dependencies[id].push(sourceFieldId);
+				}
+			})
+		);
+
+		switch (componentSchema.uiType) {
+			case "checkbox":
+			case "radio":
+				(componentSchema as ICheckboxSchema | IRadioSchema).options.forEach((option) => {
+					if (!isEmpty(option.children) && isObject(option.children)) {
+						dependencies = { ...dependencies, ...generateFieldDependencies(option.children) };
+					}
+				});
+				break;
+			default:
+				if (!isEmpty(componentSchema.children) && isObject(componentSchema.children)) {
+					dependencies = {
+						...dependencies,
+						...generateFieldDependencies(componentSchema.children as Record<string, TComponentSchema>),
+					};
+				}
+				break;
+		}
+	});
+
+	return dependencies;
+};
+
+const topologicalSort = (dependencies: Record<string, string[]>) => {
+	const fieldIds = Object.keys(dependencies);
+
+	// initialise graph representation
+	const edges: Record<string, string[]> = Object.fromEntries(fieldIds.map((id) => [id, []]));
+	const indegrees: Record<string, number> = Object.fromEntries(fieldIds.map((id) => [id, 0]));
+
+	Object.entries(dependencies).forEach(([childId, parentIds]) => {
+		parentIds.forEach((parentId) => {
+			edges[parentId].push(childId);
+		});
+	});
+	Object.entries(dependencies).forEach(([nodeId, parentIds]) => (indegrees[nodeId] = parentIds.length));
+
+	// begin graph traversal
+	const queue = [];
+	const order = [];
+
+	for (const [nodeId, count] of Object.entries(indegrees)) {
+		if (count === 0) {
+			queue.push(nodeId);
+		}
+	}
+
+	while (queue.length > 0) {
+		const nodeId = queue.shift();
+		order.push(nodeId);
+
+		for (const childId of edges[nodeId]) {
+			indegrees[childId] -= 1;
+			if (indegrees[childId] === 0) {
+				queue.push(childId);
+			}
+		}
+	}
+
+	if (order.length !== fieldIds.length) {
+		console.warn("cycle detected");
+	}
+
+	return order;
+};

--- a/src/schema-generator/types.ts
+++ b/src/schema-generator/types.ts
@@ -99,6 +99,7 @@ export interface IConditionalValidationRule extends IRule {
 
 export interface IRenderRule extends IRule {
 	filled?: boolean | undefined;
+	shown?: boolean | undefined;
 }
 export type TRenderRules = Record<string, IRenderRule[]>;
 

--- a/src/schema-generator/types.ts
+++ b/src/schema-generator/types.ts
@@ -26,7 +26,7 @@ import { IDateRangeFieldSchema } from "../fields/date-range-field";
 // =============================================================================
 // CONDITIONS AND RULES
 // =============================================================================
-export const SCHEMA_TYPES = ["string", "number", "boolean", "array", "object"] as const;
+export const SCHEMA_TYPES = ["string", "number", "boolean", "array", "object", "mixed"] as const;
 export const CONDITIONS = [
 	"required",
 	"length",

--- a/src/schema-generator/yup-helper.ts
+++ b/src/schema-generator/yup-helper.ts
@@ -25,6 +25,8 @@ export namespace YupHelper {
 				return Yup.array().typeError("Only array values are allowed");
 			case "object":
 				return Yup.object().typeError("Only object values are allowed");
+			case "mixed":
+				return Yup.mixed();
 			default:
 				console.warn(`unhandled schema type for ${type}`);
 				return Yup.mixed();


### PR DESCRIPTION
**Changes**

Add `shown` render rule

-   [delete] branch

Notes:
- in the discussed implementation, non-`shown` rules are processed first, then `shown` rules if applicable
  -  i.e. if any `showIf`  rule group can pass without depending on `shown`, then `shown` check can be skipped
- need to gracefully handle case where the target field is missing
  - e.g. B depends on A, but A is not actually defined in the schema
  - in this case, A is treated as NOT shown
- because the `shown` rule can cascade, the fields need to be processed in topological order
  - i.e. if field C depends on B depends on A, the order should be A > B > C
  - introduced a util to compute and sort the shown rule dependencies (should it be part of `generateFieldConfigs`? the recursion logic is repeated. but find it more readable to keep them separate)
  - children fields also need to be hidden if the parent fails the `shown` rule check
- there are still some scenarios that are invalid and cannot be expected to be handled deterministically:
  - cycles
  - parent depends on child