### PR TITLE
[BOOKINGSG-7753][JEFF] enhance contact-field to accept number without…

### DIFF
--- a/src/__tests__/fields/contact-field.spec.ts
+++ b/src/__tests__/fields/contact-field.spec.ts
@@ -109,6 +109,29 @@ describe("contact-field", () => {
 			expect(() => schema.validateSync({ field: "+86 131-5558-5558" })).not.toThrowError();
 		});
 
+		it("should accept phone number without white space", () => {
+			const schema = jsonToSchema({
+				section: {
+					uiType: "section",
+					children: {
+						field: {
+							uiType: "contact-field",
+							somethingUnused: "test",
+							validation: [{ contactNumber: { internationalNumber: true }, errorMessage: ERROR_MESSAGE }],
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({ field: "+390653980905" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+441624-675663" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+6003-9875-9036" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+612-1255-3456" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+8197-958-4362" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+6591234567" })).not.toThrowError();
+			expect(() => schema.validateSync({ field: "+84327016348" })).not.toThrowError();
+		});
+
 		it("should accept ambiguous calling codes as long as it is valid in a country", () => {
 			const schema = jsonToSchema({
 				section: {
@@ -169,13 +192,13 @@ describe("contact-field", () => {
 			expect(TestHelper.getError(() => schema.validateSync({ field: "+11 52-1234-5678" })).message).toBe(
 				ERROR_MESSAGE
 			); // invalid calling code
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+81 0-1234-5678" })).message).toBe(
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+84 0-1234-5678" })).message).toBe(
 				ERROR_MESSAGE
 			); // invalid area code
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+81 8811 2211" })).message).toBe(
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+84 8811 2211" })).message).toBe(
 				ERROR_MESSAGE
 			); // invalid number
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+81 52 123-45678" })).message).toBe(
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+84 52 123-45678" })).message).toBe(
 				ERROR_MESSAGE
 			); // invalid spaces
 		});
@@ -194,18 +217,14 @@ describe("contact-field", () => {
 				},
 			});
 
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+2 20-1255-3456" })).message).toBe(
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+999 123456789" })).message).toBe(
 				ERROR_MESSAGE
 			); // invalid calling code
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+61 1-1255-3456" })).message).toBe(
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+1 000-000-0000" })).message).toBe(
 				ERROR_MESSAGE
-			); // invalid area code
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+44 20-8759-903" })).message).toBe(
-				ERROR_MESSAGE
-			); // invalid number
-			expect(TestHelper.getError(() => schema.validateSync({ field: "+81 97 958-43623" })).message).toBe(
-				ERROR_MESSAGE
-			); // invalid spaces
+			); // invalid number format
+			expect(TestHelper.getError(() => schema.validateSync({ field: "+44 123" })).message).toBe(ERROR_MESSAGE); // too short
+			expect(TestHelper.getError(() => schema.validateSync({ field: "123456789" })).message).toBe(ERROR_MESSAGE); // missing country code
 		});
 
 		it("should use default error message if error message is not specified", () => {

--- a/src/fields/contact-field/phone-helper.ts
+++ b/src/fields/contact-field/phone-helper.ts
@@ -1,4 +1,4 @@
-import { CountryCode, parsePhoneNumber } from "libphonenumber-js";
+import { CountryCode, parsePhoneNumber, parsePhoneNumberFromString } from "libphonenumber-js";
 import { CountryData } from "./data";
 import { TCountry } from "./types";
 
@@ -12,6 +12,15 @@ const SINGAPORE_MOBILE_NUMBER_REGEX = /^(?!\+?6599)(?!^\+65\d{6}$)^(?:\+?(?:65)?
 
 export namespace PhoneHelper {
 	export const getParsedPhoneNumber = (value: string): IParsedPhoneNumber => {
+		const parsedValue = parsePhoneNumberFromString(value);
+		if (parsedValue) {
+			// Use countryCallingCode (string, without '+')
+			return {
+				prefix: parsedValue.countryCallingCode || "",
+				number: parsedValue.nationalNumber || "",
+			};
+		}
+		// fallback to split for manual input
 		const parsedValues = value.split(" ");
 		const hasPrefix = parsedValues.length > 1;
 
@@ -52,6 +61,8 @@ export namespace PhoneHelper {
 					? data[3] === replacedPrefix && data[0].toLowerCase() === countryName.toLowerCase()
 					: data[3] === replacedPrefix;
 			});
+
+			if (!countries.length) return false;
 
 			/**
 			 * this is not a foolproof way to determine a country by the calling code


### PR DESCRIPTION
Changes
Enhance getParsedPhoneNumber function to parse phone numbers both with and without a space between the country code and national number.

Background
Currently, the getParsedPhoneNumber function from FEE only accepts phone numbers that have a space between the country code and the national number (e.g., +65 91234567).

Issue
When a value is set for the contact field (e.g., +6591234567 without a space), the function cannot parse this format into country code and national number, resulting in validation failures later in the flow.

Expected Behavior
getParsedPhoneNumber should accept and correctly parse phone numbers both with and without a space after the country code (e.g., both +65 91234567 and +6591234567).

Additional Information

Related Jira ticket: [BOOKINGSG-7753](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7753)