### PR TITLE
Gracefully handle missing schema children

### DIFF
--- a/src/__tests__/schema-generator/json-to-schema.spec.ts
+++ b/src/__tests__/schema-generator/json-to-schema.spec.ts
@@ -105,6 +105,26 @@ describe("json-to-schema", () => {
 			expect(error.inner[0].message).toBe(ERROR_MESSAGE);
 		});
 
+		it("should gracefully handle missing schema children", () => {
+			const schema = jsonToSchema({
+				section1: {
+					uiType: "section",
+					children: undefined as any,
+				},
+				section2: {
+					uiType: "section",
+					children: {
+						div: {
+							uiType: "div",
+							children: undefined as any,
+						},
+					},
+				},
+			});
+
+			expect(() => schema.validateSync({})).not.toThrowError();
+		});
+
 		describe("overrides", () => {
 			const SCHEMA: TSectionsSchema = {
 				section: {

--- a/src/fields/generate-field-configs.ts
+++ b/src/fields/generate-field-configs.ts
@@ -47,6 +47,11 @@ export const generateFieldConfigs = (sections: TSectionsSchema) => {
 
 const generateChildrenFieldConfigs = (childrenSchema: Record<string, TComponentSchema>) => {
 	let config: TFieldsConfig<TFieldSchema | TCustomFieldSchema> = {};
+
+	if (isEmpty(childrenSchema) || !isObject(childrenSchema)) {
+		return config;
+	}
+
 	Object.entries(childrenSchema).forEach(([id, componentSchema]) => {
 		if ("referenceKey" in componentSchema) {
 			const customComponentSchema = componentSchema as TCustomFieldSchema;

--- a/src/schema-generator/conditional-render.ts
+++ b/src/schema-generator/conditional-render.ts
@@ -91,6 +91,10 @@ const parseChildrenConditionalRenders = (
 ) => {
 	let parsedYupSchema: ObjectShape = { ...yupSchema };
 
+	if (isEmpty(childrenSchema) || !isObject(childrenSchema)) {
+		return parsedYupSchema;
+	}
+
 	const parseIfValidChildren = (children: Record<string, TComponentSchema>) => {
 		if (!isEmpty(children) && isObject(children)) {
 			parsedYupSchema = {

--- a/src/schema-generator/field-sort.ts
+++ b/src/schema-generator/field-sort.ts
@@ -20,6 +20,10 @@ export const getFieldSortOrder = (sections: TSectionsSchema): Record<string, num
 const generateFieldDependencies = (childrenSchema: Record<string, TComponentSchema>) => {
 	let dependencies: Record<string, string[]> = {};
 
+	if (isEmpty(childrenSchema) || !isObject(childrenSchema)) {
+		return dependencies;
+	}
+
 	Object.entries(childrenSchema).forEach(([id, componentSchema]) => {
 		dependencies[id] = [];
 


### PR DESCRIPTION
**Changes**

- Prevent error thrown from `Object.entries` when parsing schema with undefined children
-   [delete] branch